### PR TITLE
Output filemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub-server",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "markdown site generator, web server, and editor",
   "main": "server.js",
   "preferGlobal": true,
@@ -18,7 +18,7 @@
     "express": "^4.17.1",
     "fs-extra": "^9.0.1",
     "mime": "^2.4.6",
-    "pub-generator": "^3.5.0",
+    "pub-generator": "^4.0.0",
     "pub-pkg-editor": "^2.0.2",
     "pub-pkg-font-awesome": "^3.0.4",
     "pub-pkg-font-open-sans": "^1.5.1",
@@ -26,21 +26,21 @@
     "pub-pkg-highlight": "^9.18.1",
     "pub-pkg-jquery": "^1.12.4",
     "pub-pkg-prism": "^2.0.4",
-    "pub-pkg-seo": "^1.0.13",
+    "pub-pkg-seo": "^1.0.14",
     "pub-resolve-opts": "^1.9.0",
     "pub-serve-sessions": "^1.2.3",
     "pub-src-fs": "^2.1.1",
     "pub-src-github": "^1.3.13",
-    "pub-src-http": "^1.1.3",
-    "pub-src-redis": "^2.0.1",
+    "pub-src-http": "^1.1.4",
+    "pub-src-redis": "^2.0.2",
     "pub-theme-doc": "^1.1.14",
-    "pub-util": "^3.1.1",
+    "pub-util": "^3.2.0",
     "send": "^0.17.1",
     "socket.io": "^2.3.0",
     "through2": "^3.0.1"
   },
   "devDependencies": {
-    "eslint": "^7.6.0",
+    "eslint": "^7.9.0",
     "tape": "^5.0.1"
   },
   "files": [

--- a/server.js
+++ b/server.js
@@ -105,8 +105,16 @@ function pubServer(opts) {
     var ab = asyncbuilder(function(err, a) {
       if (err) return cb(err);
       log('output %s pages, %s scripts, %s statics', a[0].length, a[1].length, a[2].length);
+
+      var filemap = u.flatten(a);
+      // check for duplicates assuming case-insensitive output file system
+      var dup$ = {};
+      u.each(filemap, function(file) {
+        if (dup$[file.path.toLowerCase()]) return log('WARNING: duplicate file in output:', file.path);
+        dup$[file.path.toLowerCase()] = 1;
+      })
       if (output.fileMap) {
-        output.src.put( [ { path:'/filemap.json', text:JSON.stringify(u.flatten(a),null,2) } ], function(err) {
+        output.src.put( [ { path:'/filemap.json', text:JSON.stringify(filemap,null,2) } ], function(err) {
           if (err) log(err);
         });
       }

--- a/server.js
+++ b/server.js
@@ -112,7 +112,7 @@ function pubServer(opts) {
       u.each(filemap, function(file) {
         if (dup$[file.path.toLowerCase()]) return log('WARNING: duplicate file in output:', file.path);
         dup$[file.path.toLowerCase()] = 1;
-      })
+      });
       if (output.fileMap) {
         output.src.put( [ { path:'/filemap.json', text:JSON.stringify(filemap,null,2) } ], function(err) {
           if (err) log(err);

--- a/server/serve-statics.js
+++ b/server/serve-statics.js
@@ -259,7 +259,7 @@ module.exports = function serveStatics(opts, cb) {
       var src = path.join(spo.sp.src.path, spo.file);
       var dest = path.join(output.path, spo.sp.route, spo.file);
 
-      var mapfile = { path:ppath.join(spo.sp.route, spo.file) }
+      var mapfile = { path:ppath.join(spo.sp.route, spo.file) };
       if (reqPath !== mapfile.path) {
         mapfile.href = reqPath;
       }

--- a/server/serve-statics.js
+++ b/server/serve-statics.js
@@ -38,10 +38,6 @@ module.exports = function serveStatics(opts, cb) {
   var staticPaths = opts.staticPaths;
   var staticPathsRev = opts.staticPaths.slice(0).reverse();
 
-  var defaultOutput = (opts.outputs && opts.outputs[0]);
-  var outputExtension = defaultOutput && defaultOutput.extension;
-  var noOutputExtensions = outputExtension === '';
-
   self.file$ = {};  // maps each possible file request path -> staticPath
   self.scanCnt = 0; // how many scans have been completed
   self.server;      // initialized by self.serveRoutes(server)
@@ -49,20 +45,17 @@ module.exports = function serveStatics(opts, cb) {
   // global opts
 
   // server retry with extensions when requested file not found - array
-  self.extensions = ('extensions' in opts) ? opts.extensions :
-    noOutputExtensions ? [] : ['.htm', '.html', '.json'];
+  self.extensions = ('extensions' in opts) ? opts.extensions : ['.htm', '.html', '.json'];
 
   // server retry with trailing slash (similar to extensions) - bool
   self.trailingSlash = 'noTrailingSlash' in opts ? !opts.noTrailingSlash : true;
 
   // additionally serve 'path/index' as just 'path' (1st match wins) - array
   // [inverse of generator.output() for pages with _href = directory]
-  self.indexFiles =
-    'indexFiles' in opts ? opts.indexFiles :
-    noOutputExtensions ? ['index'] : ['index.html'];
+  self.indexFiles = 'indexFiles' in opts ? opts.indexFiles : ['index.html'];
 
   // send Content-Type=text/html header for extensionless files
-  self.noHtmlExtensions = opts.noHtmlExtensions || noOutputExtensions;
+  self.noHtmlExtensions = opts.noHtmlExtensions;
 
   if (self.indexFiles && self.indexFiles.length) {
     self.indexFilesRe = new RegExp(
@@ -141,7 +134,7 @@ module.exports = function serveStatics(opts, cb) {
       if (src.isfile()) { sp.depth = 1; }
       sp.sendOpts = u.assign(
         u.pick(sp, 'maxAge', 'lastModified', 'etag'),
-        { dotfiles:'ignore',
+        { dotfiles:'allow',
           index:false,      // handled at this level
           extensions:false, // ditto
           root:src.path } );
@@ -235,22 +228,23 @@ module.exports = function serveStatics(opts, cb) {
     doit();
   }
 
-  // copy static files to defaultOutput preserving reqPath routes
+  // copy static files to output preserving reqPath routes
   // no error propagation, just log(err)
-  function outputAll(cb) {
+  // TODO: use output.src instead of fs.copy
+  function outputAll(output, cb) {
     cb = u.maybe(cb);
+    output = output || opts.outputs[0];
 
     var count = u.size(self.file$);
-    var result = [];
+    var filemap = [];
 
-    if (!defaultOutput || !count) return cb(log('statics.outputAll: no output'));
+    if (!count) return cb(null, filemap);
 
     var done = u.after(count, function() {
-      log('output %s %s static files', defaultOutput.path, result.length);
-      cb(result);
+      cb(null, filemap);
     });
 
-    var omit = defaultOutput.omitRoutes;
+    var omit = output.omitRoutes;
     if (omit && !u.isArray(omit)) { omit = [omit]; }
 
     // TODO: re-use similar filter in generator.output and serve-scripts.outputAll
@@ -263,12 +257,17 @@ module.exports = function serveStatics(opts, cb) {
       if (filterRe.test(reqPath)) return done();
 
       var src = path.join(spo.sp.src.path, spo.file);
-      var dest = path.join(defaultOutput.path, spo.sp.route, spo.file);
+      var dest = path.join(output.path, spo.sp.route, spo.file);
+
+      var mapfile = { path:ppath.join(spo.sp.route, spo.file) }
+      if (reqPath !== mapfile.path) {
+        mapfile.href = reqPath;
+      }
 
       // copy will create dirs if necessary
       fs.copy(src, dest, function(err) {
         if (err) return done(log(err));
-        result.push(dest);
+        filemap.push(mapfile);
         done();
       });
 

--- a/server/serve-statics.js
+++ b/server/serve-statics.js
@@ -241,7 +241,7 @@ module.exports = function serveStatics(opts, cb) {
     if (!count) return cb(null, filemap);
 
     var done = u.after(count, function() {
-      cb(null, filemap);
+      cb(null, u.sortBy(filemap, 'path'));
     });
 
     var omit = output.omitRoutes;


### PR DESCRIPTION
- output.fileMap - pub -O will generate output manifest in filemap.json with pages, statics, and scripts
- temporily removed unused editor apis: 
  - /admin/reloadSources
  - /admin/outputPages
  - /admin/logPages
  - /admin/reloadSources

from pub-generator v4.0.0:
- opts.parentFolderWarnings displays warning if page tree is missing folder nodes
- output.outputAliases - use redirect template (not provided) to generate html-based redirects for aliases
- page.noextension - prevents auto .html extension for that page on output
